### PR TITLE
Bump versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-markdown "0.1.4"
+(defproject cryogen-markdown "0.1.5"
   :description "Markdown parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-markdown"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cryogen-core "0.1.41"]
-                 [markdown-clj "0.9.89"]])
+                 [markdown-clj "0.9.94"]])


### PR DESCRIPTION
I need the escape nested code blocks feature from the newest version of markdown-clj to explain something on cryogen-docs.
