### PR TITLE
Allow multiple extensions in  Markup.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject cryogen-markdown "0.1.11"
+(defproject cryogen-markdown "0.1.12"
   :description "Markdown parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-markdown"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [cryogen-core "0.1.67"]
+                 [cryogen-core "0.3.2"]
                  [markdown-clj "1.10.0"]])

--- a/src/cryogen_markdown/core.clj
+++ b/src/cryogen_markdown/core.clj
@@ -17,7 +17,7 @@
   []
   (reify Markup
     (dir [this] "md")
-    (ext [this] ".md")
+    (exts [this] #{".md"})
     (render-fn [this]
       (fn [rdr config]
         (md-to-html-string


### PR DESCRIPTION
Addresses Issue  Number 6 in the `cryogen-asciidoc` repo.
For the set of related PRs see the main PR on the `cryogen-core` repo.